### PR TITLE
Use async_executors from latest commit to fix cargo test

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,4 +23,4 @@ thiserror = "1.0"
 tokio = { version = "1.0", features = ["rt"] }
 
 [dev-dependencies]
-async_executors = { version = "0.4", features = ["tokio_tp"] }
+async_executors = { git = "https://github.com/najamelan/async_executors", rev = "ff861e6ba97a7490ea324a614cefbeca540127fd", features = ["tokio_tp"]}


### PR DESCRIPTION
This changes async_executors to use the latest commit on their main branch, so the nightly build passes.
This is the commit we need in there: https://github.com/najamelan/async_executors/commit/11d783d5f022dd0746002c93d90da78da4b44352