### PR TITLE
use a concrete error type that can be converted to anyhow

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -172,10 +172,7 @@ impl HoneycombPipelineBuilder {
     /// Install the Honeycomb exporter pipeline with the recommended defaults.
     pub fn install(
         mut self,
-    ) -> Result<
-        (HoneycombFlusher, opentelemetry::sdk::trace::Tracer),
-        Box<dyn std::error::Error + Send + Sync>,
-    > {
+    ) -> Result<(HoneycombFlusher, opentelemetry::sdk::trace::Tracer), HoneycombError> {
         let client = libhoney::init(libhoney::Config {
             executor: self.executor,
             options: libhoney::client::Options {


### PR DESCRIPTION
anyhow will refuse to convert Box<dyn Error + ...> using the ? operator

```
error[E0277]: the size for values of type `dyn std::error::Error + Send + Sync` cannot be known at compilation time
  --> src/main.rs:58:15
   |
58 |     .install()?;
   |               ^ doesn't have a size known at compile-time
   |
   = help: the trait `Sized` is not implemented for `dyn std::error::Error + Send + Sync`
   = help: the following other types implement trait `FromResidual<R>`:
             <Result<T, F> as FromResidual<Result<Infallible, E>>>
             <Result<T, F> as FromResidual<Yeet<E>>>
   = note: required because of the requirements on the impl of `std::error::Error` for `Box<dyn std::error::Error + Send + Sync>`
   = note: required because of the requirements on the impl of `From<Box<dyn std::error::Error + Send + Sync>>` for `anyhow::Error`
   = note: required because of the requirements on the impl of `FromResidual<Result<Infallible, Box<dyn std::error::Error + Send + Sync>>>` for `Result<(), anyhow::Error>`

For more information about this error, try `rustc --explain E0277`.
```

I feel like I've worked around this problem already on a previous project, but I can't remember how I did it, and my head is a bit foggy (I decided to do some weekend hacking even though I have been in bed with a cold for a week). In the end, I decided to work around it by returning the concrete type that we're receiving from `libhoney::init()`.

Are we expecting install() to return any other type of error, or is this fine?

As an aside, the reason I was messing about with this library in an attempt to visualise my CI builds (code lives at https://github.com/alsuren/experiments/tree/main/ci-logs-to-otel and I was testing it with `cargo +nightly watch -c -s 'env HONEYCOMB_API_KEY=xxx RUST_BACKTRACE=1 GITHUB_OWNER=yyy GITHUB_REPO=zzz GITHUB_TOKEN=aaa HONEYCOMB_DATASET="ci-logs-$(date)" cargo run'`) but I was hitting rate-limits (unsurprisingly - maybe I should add some sleeps in there) and getting a bunch of missing spans and seemingly duplicate spans, plus some spans with strange durations that don't match up with what I was expecting, so I gave up. There's probably something really obvious that I'm doing wrong, but it's just as likely to be a problem with parsing as it is with my abuse of opentelemetry.